### PR TITLE
Add prompt engineering and basic analysis output generation

### DIFF
--- a/service/.gitignore
+++ b/service/.gitignore
@@ -10,9 +10,6 @@ env/
 # Environment variables file (keep this private)
 .env
 
-
-
-
-
-
-
+# IDE and tools specific
+.history
+.vscode

--- a/service/event_analysis_engine/event_analysis_engine.py
+++ b/service/event_analysis_engine/event_analysis_engine.py
@@ -1,0 +1,116 @@
+import json
+import re
+from typing import Dict, List, Optional
+import ollama
+
+from prompt import EVENT_ANALYSIS_PROMPT
+
+LLM = "llama3"
+TEMPERATURE = 0.2
+
+def create_prompt(
+    frontend_events: List[Dict], 
+    backend_events: List[Dict], 
+    frontend_logs: List[Dict], 
+    backend_logs: List[Dict]
+) -> str:
+    """
+    Generates a prompt by replacing placeholders in `EVENT_ANALYSIS_PROMPT` with 
+    JSON-formatted frontend and backend events and logs.
+
+    Args:
+        - frontend_events (List[Dict]): Frontend analytical events.
+        - backend_events (List[Dict]): Backend analytical events.
+        - frontend_logs (List[Dict]): Frontend error logs.
+        - backend_logs (List[Dict]): Backend error logs.
+
+    Returns:
+        str: The formatted prompt with data in place of placeholders.
+
+    Example:
+        - Input:
+            frontend_events = [{"id": 1}], backend_events = [{"id": 2}], 
+            frontend_logs = [{"id": "log1"}], backend_logs = [{"id": "log2"}]
+        - Output:
+            A formatted string with the provided data in JSON format.
+
+    Raises:
+        - ValueError: If inputs are not lists of dictionaries.
+    """
+    
+    # Serialize inputs to JSON strings
+    fe_events_json = json.dumps(frontend_events, indent=2)
+    be_events_json = json.dumps(backend_events, indent=2)
+    fe_logs_json = json.dumps(frontend_logs, indent=2)
+    be_logs_json = json.dumps(backend_logs, indent=2)
+    
+    # Replace placeholders in the prompt
+    prompt = EVENT_ANALYSIS_PROMPT
+    prompt = prompt.replace("<FE_EVENTS>", fe_events_json)
+    prompt = prompt.replace("<BE_EVENTS>", be_events_json)
+    prompt = prompt.replace("<FE_LOGS>", fe_logs_json)
+    prompt = prompt.replace("<BE_LOGS>", be_logs_json)
+    
+    return prompt
+    
+def analyse_events_and_logs(
+    frontend_events: List[Dict], 
+    backend_events: List[Dict], 
+    frontend_logs: List[Dict], 
+    backend_logs: List[Dict]
+) -> Optional[Dict]:
+    """
+    Analyzes frontend and backend events and logs using an LLM model and returns structured insights.
+
+    Args:
+        - frontend_events (List[Dict]): Frontend analytical events.
+        - backend_events (List[Dict]): Backend analytical events.
+        - frontend_logs (List[Dict]): Frontend error logs.
+        - backend_logs (List[Dict]): Backend error logs.
+
+    Returns:
+        Optional[Dict]: Parsed JSON response from the LLM containing event analysis, or `None` if parsing fails.
+
+    Steps:
+        - 1. Generates a prompt using `create_prompt`.
+        - 2. Sends the prompt to the LLM via `ollama.chat`.
+        - 3. Extracts and parses the JSON content from the LLM response.
+        - 4. Returns the parsed JSON or `None` if the response is invalid.
+
+    Example:
+        - Input:
+            frontend_events = [{"id": 1}], backend_events = [{"id": 2}],
+            frontend_logs = [{"id": "log1"}], backend_logs = [{"id": "log2"}]
+        - Output:
+            Parsed JSON structure with event insights, or `None` if invalid.
+
+    Raises:
+        None: Handles parsing errors gracefully by returning `None`.
+    """
+    
+    prompt = create_prompt(
+        frontend_events=frontend_events,
+        backend_events=backend_events,
+        frontend_logs=frontend_logs,
+        backend_logs=backend_logs
+    )
+    
+    response = ollama.chat(
+        model=LLM,
+        options={"temperature": TEMPERATURE},
+        messages=[{"role": "user", "content": prompt}],
+    )
+    
+    response_text = response.get("message", {}).get("content", "")
+    response_text_json = re.search(r"\{.*\}", response_text, re.DOTALL)
+    
+    if response_text_json:
+        try:
+            response_text_json = json.loads(response_text_json.group())
+        except json.JSONDecodeError as e:
+            response_text_json = None
+    else:
+        response_text_json = None
+    
+    print(response_text_json)
+    return response_text_json

--- a/service/event_analysis_engine/prompt.py
+++ b/service/event_analysis_engine/prompt.py
@@ -1,0 +1,43 @@
+EVENT_ANALYSIS_PROMPT = """
+Analyze the provided data containing analytical events and error logs to identify details about failed events and their related logs. Your task is to:
+1. Look at the failed analytical events (both frontend and backend).
+2. Cross-reference them with error logs (frontend and backend) to identify which logs are related to which failed event.
+3. Provide insights into why each event failed (possible reasons behind the failure).
+4. Determine if the failure is fixable or not.
+5. Add any additional relevant remarks.
+
+Output Format:
+Return your findings as a JSON object with the following structure:
+
+```json
+{
+    "result": [
+        {
+            "event_id": "", // uuid of this event
+            "logs": [1, 2, 3], // IDs of the logs related to this event failure
+            "reason": "", // one of these: ad-blocker-plugin,ad-blocking-browser,network-failure,browser-policy,service-unavailability
+            "insights": ["insight 1", "insight 2"], // Insights about what went wrong
+            "fixable": false, // True if the issue is fixable, false otherwise
+            "remark": "" // Additional detailed remarks
+        }
+    ]
+}
+```
+
+Important: The response must be in JSON format only, without any additional text or explanation.
+
+Data:
+Frontend Analytical Failed Events:
+<FE_EVENTS>
+
+Backend Analytical Failed Events:
+<BE_EVENTS>
+
+Error Logs:
+<FE_LOGS>
+
+Backend:
+<BE_LOGS>
+
+Analyze the data, identify the relationships, reasons, fixability, and remarks for the failed events, and respond strictly in the specified JSON format.
+"""


### PR DESCRIPTION
This PR introduces two methods, **create_prompt** and **analyse_events_and_logs**, to generate and analyze insights from frontend and backend events and logs using an LLM model.