### PR TITLE
#15 Create api to insert events in DB

### DIFF
--- a/service/.env.example
+++ b/service/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://<username>:<password>@<host>/<db_name>?sslmode=require

--- a/service/app/main.py
+++ b/service/app/main.py
@@ -1,10 +1,12 @@
 from typing import Union
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 
 from models.handler.event import EventRequest
 from models.handler.log import LogRequest
 from utils.db_helper import execute_query
+
+from utils.response import success_response, error_response
 
 app = FastAPI()
 
@@ -20,7 +22,7 @@ def read_ping():
 
 
 @app.post("/event")
-async def receive_event(event: EventRequest):
+async def receive_event(event: EventRequest,response: Response):
     """
     Receive an event and insert it into the database.
     """
@@ -50,9 +52,9 @@ async def receive_event(event: EventRequest):
             event.ab_active,
             event.p_installed
         ))
-        return {"message": "Event inserted successfully"}
+        return success_response(response, "event received", 201)
     except Exception as e:
-        return {"error": f"Failed to insert event: {e}"}
+        return error_response(response, e, 400)
 
 
 @app.post("/log")

--- a/service/app/models/db/event.py
+++ b/service/app/models/db/event.py
@@ -1,0 +1,17 @@
+class EventDBModel:
+    def __init__(self, uuid, source, url, payload, status, result, user_agent, ad_blocker_active, plugin_installed):
+        self.uuid = uuid
+        self.source = source
+        self.url = url
+        self.payload = payload
+        self.status = status
+        self.result = result
+        self.user_agent = user_agent
+        self.ad_blocker_active = ad_blocker_active
+        self.plugin_installed = plugin_installed
+
+    def as_tuple(self):
+        return (
+            self.uuid, self.source, self.url, self.payload, self.status,
+            self.result, self.user_agent, self.ad_blocker_active, self.plugin_installed
+        )

--- a/service/app/models/handler/event.py
+++ b/service/app/models/handler/event.py
@@ -3,12 +3,18 @@ from pydantic import BaseModel
 from models.source import SourceType
 
 
+from enum import Enum
+
+class ResultType(str, Enum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILED"
+
+
 class EventRequest(BaseModel):
     uuid: str
     source: SourceType
     url: str
-    success: bool
-    status: str
+    result: ResultType
     user_agent: Optional[str] = None
     ab_active: bool
     p_installed: Optional[List[str]] = None 

--- a/service/app/models/handler/log.py
+++ b/service/app/models/handler/log.py
@@ -1,8 +1,6 @@
-from typing import Optional, Dict, Any,List
+from typing import Optional, Dict, List
 from pydantic import BaseModel
 from models.source import SourceType
-
-from enum import Enum
 
 class LogRequest(BaseModel):
     uuid: str

--- a/service/app/utils/db_helper.py
+++ b/service/app/utils/db_helper.py
@@ -1,6 +1,9 @@
-from app.database import get_db_connection
+from database import get_db_connection
 
 def execute_query(query, params=None):
+    """
+    Execute a query on the database.
+    """
     connection = get_db_connection()
     try:
         with connection.cursor() as cursor:

--- a/service/app/utils/response.py
+++ b/service/app/utils/response.py
@@ -1,0 +1,12 @@
+
+from fastapi import  Response
+
+# Function to handle success response
+def success_response(response: Response, message: str, status_code: int):
+    response.status_code = status_code
+    return {"message": message}
+
+# Function to handle failure response
+def error_response(response: Response, error_message: str,status_code:int):
+    response.status_code = status_code
+    return {"error": f"Failed to insert event: {error_message}"}

--- a/service/migrations/create_table.sql
+++ b/service/migrations/create_table.sql
@@ -1,6 +1,6 @@
 CREATE TYPE source_enum AS ENUM ('F', 'B');
-CREATE TYPE status_enum AS ENUM ('pending', 'processed');
-CREATE TYPE result_enum AS ENUM ('success', 'failed');
+CREATE TYPE status_enum AS ENUM ('PENDING', 'PROCESSED');
+CREATE TYPE result_enum AS ENUM ('SUCCESS', 'FAILED');
 
 CREATE TABLE events (
             id SERIAL PRIMARY KEY,
@@ -8,13 +8,13 @@ CREATE TABLE events (
             source source_enum NOT NULL,
             url VARCHAR(255) NOT NULL,
             payload TEXT,
-            status status_enum NOT NULL DEFAULT 'pending',
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP NOT NULL,
+            status status_enum NOT NULL DEFAULT 'PENDING',
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
             result result_enum NOT NULL,
             user_agent VARCHAR(255),
             ad_blocker_active BOOLEAN NOT NULL,
-            plugin_installed VARCHAR(255)
+            plugin_installed TEXT
 );
 
 CREATE TABLE error_logs (
@@ -22,9 +22,9 @@ CREATE TABLE error_logs (
             uuid VARCHAR(255) NOT NULL,
             log TEXT,
             title VARCHAR(255),
-            status status_enum NOT NULL DEFAULT 'pending',
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP NOT NULL,
+            status status_enum NOT NULL DEFAULT 'PENDING',
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
             source source_enum NOT NULL
 );
 
@@ -35,7 +35,7 @@ CREATE TABLE analysis (
             insights VARCHAR(255),
             fixable BOOLEAN DEFAULT FALSE,
             remarks TEXT,
-            created_at TIMESTAMP NOT NULL,
-            updated_at TIMESTAMP NOT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
             FOREIGN KEY (event_id) REFERENCES events (id)
 );


### PR DESCRIPTION
### Create API to Insert Events in DB

**Summary:**  
This PR adds a POST API (`/event`) to receive event data and insert it into the `events` table in the database. The event data is processed and an SQL query is executed to insert it.

**Changes:**  
- Added `EventRequest` model to validate the incoming request.  
- Implemented `/event` POST endpoint to handle event insertion into the database.  
- Created a reusable `execute_query` function for interacting with the database.

**How to Test:**  
- Send a POST request to `/event` with the event data.
- Verify that the event data is successfully inserted into the `events` table.
